### PR TITLE
Switch search engine to Tavily AI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 OPENAI_API_KEY=
-SEARCH_API_KEY=
+TAVILY_API_KEY=
 REDIS_URL=redis://localhost:6379
 DATABASE_URL=postgresql://localhost/curio
 INTERVIEWER_MODEL=gpt-4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ httpx
 redis
 psycopg2-binary
 python-dotenv
+tavily-python

--- a/src/tools/web_search.py
+++ b/src/tools/web_search.py
@@ -1,17 +1,11 @@
-"""Simple web search utility."""
+"""Simple web search utility using Tavily's Python SDK."""
 
 from typing import List
-import httpx
-import os
+from tavily import AsyncTavilyClient
 
-SEARCH_API_ENDPOINT = "https://api.bing.microsoft.com/v7.0/search"
 
 async def web_search(query: str, max_calls: int = 3) -> List[str]:
-    api_key = os.getenv("SEARCH_API_KEY")
-    headers = {"Ocp-Apim-Subscription-Key": api_key}
-    params = {"q": query, "count": str(max_calls)}
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(SEARCH_API_ENDPOINT, headers=headers, params=params)
-        resp.raise_for_status()
-        data = resp.json()
-        return [item.get('snippet', '') for item in data.get('webPages', {}).get('value', [])]
+    """Query Tavily and return snippet texts."""
+    client = AsyncTavilyClient()
+    data = await client.search(query, max_results=max_calls)
+    return [item.get("content", "") for item in data.get("results", [])]

--- a/src/tools/web_search.py
+++ b/src/tools/web_search.py
@@ -6,6 +6,6 @@ from tavily import AsyncTavilyClient
 
 async def web_search(query: str, max_calls: int = 3) -> List[str]:
     """Query Tavily and return snippet texts."""
-    client = AsyncTavilyClient()
-    data = await client.search(query, max_results=max_calls)
-    return [item.get("content", "") for item in data.get("results", [])]
+    async with AsyncTavilyClient() as client:
+        data = await client.search(query, max_results=max_calls)
+        return [item.get("content", "") for item in data.get("results", [])]


### PR DESCRIPTION
## Summary
- use Tavily Search API for web lookups
- document the new `TAVILY_API_KEY` env var
- integrate official Tavily Python SDK
- remove Tavily name from README

## Testing
- `python -m compileall -q src`
- `pytest -q`
- `npm install --silent` *(fails: command not found)*
- `npm run build --silent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687599e1ad6883328c38072d47a22825